### PR TITLE
Changes to bot and intents.

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,10 +17,15 @@ intitial_extensions = ["cogs.admin",
                        "cogs.fun",
                        "cogs.events"]
 
-bot = commands.Bot(command_prefix=_get_prefix, 
-                   owner_id=737928480389333004, 
-                   help_command=None,
-                   intents=discord.Intents.all())
+intents = discord.Intents.default()
+intents.typing = False
+intents.members = True
+intents.presences = True
+
+bot = commands.AutoShardedBot(command_prefix=_get_prefix, 
+                              owner_id=737928480389333004, 
+                              help_command=None,
+                              intents=intents)
 
 if __name__ == "__main__":
     for extension in intitial_extensions:


### PR DESCRIPTION
# Summary
Instead of using the `commands.Bot` instance we are going to use the `commands.AutoShardedBot` for greater growing capacity.

As well as this the use of intents has changed: 
Before:
```py
intents = discord.Intents.all()
``` 

After

```py
intents = discord.Intents.default()
intents.typing = False
intents.members = True
intents.presences = True
```
discord.Intents.default() gives us every intent except from the higher tier ones (members and presences) but we wish to disable the typing intent because it is spammy and we don't need it. 

The changes to the intents could *in theory* make the bot run faster in the long run. Sharding will also help that.